### PR TITLE
Feature - Generalize List

### DIFF
--- a/packages/sentry-client-web/src/components/List.tsx
+++ b/packages/sentry-client-web/src/components/List.tsx
@@ -59,7 +59,6 @@ export class List extends React.Component<IListProps, IListState> {
             return;
         }
 
-        let errorMessage;
         let displayEntities;
         let DisplayEntity;
         switch (this.props.view) {

--- a/packages/sentry-client-web/src/components/List.tsx
+++ b/packages/sentry-client-web/src/components/List.tsx
@@ -80,7 +80,7 @@ export class List extends React.Component<IListProps, IListState> {
         } else {
             return (
                 <div style={this.getStyle()}>
-                    {displayEntities.map((entity: any, index: number) => {
+                    {displayEntities.map((entity: Object, index: number) => {
                         return (
                             <div>
                                 <DisplayEntity

--- a/packages/sentry-client-web/src/components/List.tsx
+++ b/packages/sentry-client-web/src/components/List.tsx
@@ -37,7 +37,8 @@ export class List extends React.Component<IListProps, IListState> {
     }
 
     public getServices() {
-        return Object.keys(this.props.servers).map((serverKey: string) => servers[serverKey]).reduce(
+        const servers = this.props.servers;
+        return Object.keys(servers).map((serverKey: string) => servers[serverKey]).reduce(
             (prev, current: IServer) => current.serviceInfo ?
                 prev.concat(Object.keys(current.serviceInfo)
                     .map((serviceKey: string) => current.serviceInfo && current.serviceInfo[serviceKey]))
@@ -59,12 +60,12 @@ export class List extends React.Component<IListProps, IListState> {
             return;
         }
 
-        let displayEntities;
-        let DisplayEntity;
+        let displayEntities: Object[];
+        let DisplayEntity: any;
         switch (this.props.view) {
             case EView.servers:
                 DisplayEntity = Server;
-                displayEntities = Object.values(servers);
+                displayEntities = Object.keys(servers).map((serverKey: string) => servers[serverKey]);
                 break;
             case EView.services:
                 DisplayEntity = Service;

--- a/packages/sentry-client-web/src/components/List.tsx
+++ b/packages/sentry-client-web/src/components/List.tsx
@@ -60,7 +60,7 @@ export class List extends React.Component<IListProps, IListState> {
             return;
         }
 
-        let displayEntities: Object[];
+        let displayEntities: object[];
         let DisplayEntity: any;
         switch (this.props.view) {
             case EView.servers:
@@ -80,7 +80,7 @@ export class List extends React.Component<IListProps, IListState> {
         } else {
             return (
                 <div style={this.getStyle()}>
-                    {displayEntities.map((entity: Object, index: number) => {
+                    {displayEntities.map((entity: object, index: number) => {
                         return (
                             <div>
                                 <DisplayEntity

--- a/packages/sentry-client-web/src/components/List.tsx
+++ b/packages/sentry-client-web/src/components/List.tsx
@@ -66,23 +66,17 @@ export class List extends React.Component<IListProps, IListState> {
             case EView.servers:
                 DisplayEntity = Server;
                 displayEntities = Object.values(servers);
-                if (Object.keys(servers).length > 0) {
-                  errorMessage = `No ${EView.servers}`;
-                }
                 break;
             case EView.services:
                 DisplayEntity = Service;
                 displayEntities = this.getServices();
-                if (displayEntities.length < 0) {
-                  errorMessage = `No ${EView.services}`;
-                }
                 break;
             default:
                 throw new Error("Switch statement should be exhaustive");
         }
 
-        if (errorMessage) {
-            return <MessageBox message={errorMessage} />;
+        if (displayEntities.length === 0) {
+            return <MessageBox message={`No ${this.props.view}`} />;
         } else {
             return (
                 <div style={this.getStyle()}>

--- a/packages/sentry-client-web/src/components/List.tsx
+++ b/packages/sentry-client-web/src/components/List.tsx
@@ -37,12 +37,7 @@ export class List extends React.Component<IListProps, IListState> {
     }
 
     public getServices() {
-        const servers = this.props.servers;
-        if (servers === undefined) {
-            return;
-        }
-
-        return Object.keys(servers).map((serverKey: string) => servers[serverKey]).reduce(
+        return Object.keys(this.props.servers).map((serverKey: string) => servers[serverKey]).reduce(
             (prev, current: IServer) => current.serviceInfo ?
                 prev.concat(Object.keys(current.serviceInfo)
                     .map((serviceKey: string) => current.serviceInfo && current.serviceInfo[serviceKey]))
@@ -58,72 +53,51 @@ export class List extends React.Component<IListProps, IListState> {
         };
     }
 
-    public renderServers(): JSX.Element {
-        if (this.props.servers && Object.keys(this.props.servers).length > 0) {
-            return (
-                <div style={this.getStyle()}>
-                    {Object.keys(this.props.servers).map((id, index) => {
-                        if (!this.props.servers || !this.props.servers[id]) {
-                            return null;
-                        }
+    public render() {
+        const servers = this.props.servers;
+        if (servers === undefined) {
+            return;
+        }
 
-                        return <Server
-                            index={index}
-                            key={index}
-                            server={this.props.servers[id]} />;
-                    })}
-                </div>
-            );
+        let errorMessage;
+        let displayEntities;
+        let DisplayEntity;
+        switch (this.props.view) {
+            case EView.servers:
+                DisplayEntity = Server;
+                displayEntities = Object.values(servers);
+                if (Object.keys(servers).length > 0) {
+                  errorMessage = `No ${EView.servers}`;
+                }
+                break;
+            case EView.services:
+                DisplayEntity = Service;
+                displayEntities = this.getServices();
+                if (displayEntities.length < 0) {
+                  errorMessage = `No ${EView.services}`;
+                }
+                break;
+            default:
+                throw new Error("Switch statement should be exhaustive");
+        }
+
+        if (errorMessage) {
+            return <MessageBox message={errorMessage} />;
         } else {
-            const style = {
-                width: "100%",
-                height: "300px"
-            };
-            return (
-                <MessageBox message={"No servers"} style={style} />
-            );
-        }
-    }
-
-    public renderServices(): JSX.Element | null {
-        const services = this.getServices();
-        if (services === undefined) {
-            return null;
-        }
-
-        if (services.length > 0) {
             return (
                 <div style={this.getStyle()}>
-                    {services.map((service: any, index: number) => {
+                    {displayEntities.map((entity: any, index: number) => {
                         return (
                             <div>
-                                <Service
+                                <DisplayEntity
                                     key={index}
-                                    service={service} />
+                                    index={index}
+                                    data={entity} />
                             </div>
                         );
                     })}
                 </div>
             );
-        } else {
-            const style = {
-                width: "100%",
-                height: "300px"
-            };
-            return (
-                <MessageBox message={"No servers"} style={style} />
-            );
-        }
-    }
-
-    public render() {
-        switch (this.props.view) {
-            case EView.servers:
-                return this.renderServers();
-            case EView.services:
-                return this.renderServices();
-            default:
-                return null;
         }
     }
 }

--- a/packages/sentry-client-web/src/components/MessageBox.tsx
+++ b/packages/sentry-client-web/src/components/MessageBox.tsx
@@ -12,6 +12,8 @@ export class MessageBox extends React.Component<IMessageBoxProps, any> {
             display: "flex",
             alignItems: "center",
             justifyContent: "center",
+            width: "100%",
+            height: "300px",
             ...this.props.style
         };
     }

--- a/packages/sentry-client-web/src/components/Server.tsx
+++ b/packages/sentry-client-web/src/components/Server.tsx
@@ -11,7 +11,7 @@ import { formatBytes } from "../lib/utils";
 import { pretty } from "../utils/prettyTime";
 
 interface IStateProps {
-    server: IServer;
+    data: IServer;
     index: number;
     expanded?: boolean;
 }
@@ -80,20 +80,20 @@ export class Server extends React.Component<IStateProps & IDispatchProps, any> {
 
     // Render
     public renderStatus(): JSX.Element {
-        const status = this.props.server.status ? this.props.server.status : EStatus.unknown;
+        const status = this.props.data.status ? this.props.data.status : EStatus.unknown;
         return (
             <Status status={status} />
         );
     }
 
     public renderData(): JSX.Element | null {
-        // const staticInfo = this.props.server.staticInfo;
+        // const staticInfo = this.props.data.staticInfo;
 
-        if (!this.props.server.dynamicInfo) {
+        if (!this.props.data.dynamicInfo) {
             return null;
         }
 
-        const dynamicInfo = this.props.server.dynamicInfo;
+        const dynamicInfo = this.props.data.dynamicInfo;
 
         const cpuModel = dynamicInfo.cpus[0].model.split("@")[0];
         // const cpuSpeed = dynamicInfo.cpus[0].model.split("@")[1];
@@ -141,7 +141,7 @@ export class Server extends React.Component<IStateProps & IDispatchProps, any> {
         return (
             <div style={{ marginTop: "0.5em" }}>
                 {this.renderRow("hostname:", dynamicInfo.hostname)}
-                {this.renderRow("host:", this.props.server.host)}
+                {this.renderRow("host:", this.props.data.host)}
                 {this.renderRow("uptime:", pretty(dynamicInfo.uptime, 2))}
                 {this.renderRow("cpu:", cpuModel)}
                 {renderCpuCores()}
@@ -161,7 +161,7 @@ export class Server extends React.Component<IStateProps & IDispatchProps, any> {
             };
         }
 
-        const services = this.props.server.serviceInfo;
+        const services = this.props.data.serviceInfo;
 
         if (!services) {
             return null;
@@ -233,7 +233,7 @@ export class Server extends React.Component<IStateProps & IDispatchProps, any> {
                 <div>
                     <span>
                         {this.renderStatus()}
-                        {this.props.server.name}
+                        {this.props.data.name}
                     </span>
                     {this.state.hover ? this.renderChevron() : null}
                 </div>

--- a/packages/sentry-client-web/src/components/Service.tsx
+++ b/packages/sentry-client-web/src/components/Service.tsx
@@ -6,7 +6,7 @@ import { EStatus } from "../constants";
 import { IService } from "../reducer";
 
 interface IStateProps {
-    service: IService;
+    data: IService;
 }
 
 export class Service extends React.Component<IStateProps, any> {
@@ -21,7 +21,7 @@ export class Service extends React.Component<IStateProps, any> {
 
     // Render
     public renderStatus(): JSX.Element {
-        const status = this.props.service.status ? EStatus.available : EStatus.outage;
+        const status = this.props.data.status ? EStatus.available : EStatus.outage;
         return (
             <Status status={status} />
         );
@@ -34,7 +34,7 @@ export class Service extends React.Component<IStateProps, any> {
                 <div>
                     <span>
                         {this.renderStatus()}
-                        {this.props.service.name}
+                        {this.props.data.name}
                     </span>
                 </div>
             </div>

--- a/packages/sentry-client-web/test/components/Server.test.tsx
+++ b/packages/sentry-client-web/test/components/Server.test.tsx
@@ -13,7 +13,7 @@ describe("Server", () => {
 		};
 
 		const component = renderer.create(
-			<Server server={server} index={0} />
+			<Server data={server} index={0} />
 		);
 
 		const tree = component.toJSON();

--- a/packages/sentry-client-web/test/components/Service.test.tsx
+++ b/packages/sentry-client-web/test/components/Service.test.tsx
@@ -7,7 +7,7 @@ describe("Service", () => {
 
     it("renders a basic Service", () => {
         const component = renderer.create(
-            <Service service={{name: "test", script: "test", test: "test", status: false}} />
+            <Service data={{name: "test", script: "test", test: "test", status: false}} />
         );
 
         const tree = component.toJSON();


### PR DESCRIPTION
This PR removes the `renderServers` and `renderServices` methods and generalizes the code for rendering `servers` and `services` as `displayEntities`

@sbuggay 